### PR TITLE
use the site's known url base to prefix the url base for the search index

### DIFF
--- a/generators/lunr.fsx
+++ b/generators/lunr.fsx
@@ -9,9 +9,9 @@
 
 open Apirefloader
 open FSharp.Formatting.ApiDocs
-
 let generate (ctx : SiteContents) (projectRoot: string) (page: string) =
     let all = ctx.TryGetValues<AssemblyEntities>()
+    let siteInfo = ctx.TryGetValue<SiteInfo>() |> Option.get
     let refs =
       match all with
       | None -> [| |]
@@ -19,7 +19,7 @@ let generate (ctx : SiteContents) (projectRoot: string) (page: string) =
         match List.ofSeq all with
         | [model] ->
             let model = { model.GeneratorOutput with
-                                CollectionRootUrl = "/reference/FSharp.Core" }
+                                CollectionRootUrl = siteInfo.root_url + "/reference/FSharp.Core" }
             ApiDocs.GenerateSearchIndexFromModel model
         | _ ->
             [| |]


### PR DESCRIPTION
Fixes #25 by changing how we generate the search index.

The previous method didn't take the site's hosting root into consideration, instead it lopped off path prefixes and generated routes from the domain only.

This method uses the site's known root url (which includes the path base) to generate the url base from the search index.  This works locally well, and I expect it to work when deployed as well.